### PR TITLE
Base off gliderlabs/alpine image instead of ubuntu-debootstrap

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -1,14 +1,10 @@
-FROM ubuntu-debootstrap:trusty
-MAINTAINER Glider Labs <team@gliderlabs.com>
+FROM gliderlabs/alpine:3.1
 
-ENV PYTHON_VERSION 2.7
-
-RUN apt-get update -y \
-    && apt-get install --no-install-recommends -y -q \
-        build-essential python$PYTHON_VERSION python$PYTHON_VERSION-dev python-pip \
-    && apt-get clean \
-    && pip install -U pip \
-    && hash -r \
+RUN apk-install \
+        python \
+        python-dev \
+        py-pip \
+        build-base \
     && pip install virtualenv \
     && echo "Dockerfile" >> /etc/buildfiles \
     && echo ".onbuild" >> /etc/buildfiles \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -1,14 +1,9 @@
-FROM ubuntu-debootstrap:trusty
-MAINTAINER Glider Labs <team@gliderlabs.com>
+FROM gliderlabs/alpine:3.1
 
-ENV PYTHON_VERSION 3.4
-
-RUN apt-get update -y \
-    && apt-get install --no-install-recommends -y -q \
-        build-essential python$PYTHON_VERSION python$PYTHON_VERSION-dev python3-pip \
-    && apt-get clean \
-    && pip3 install -U pip \
-    && hash -r \
+RUN apk-install -X http://dl-4.alpinelinux.org/alpine/edge/testing \
+        python3 \
+        python3-dev \
+        build-base \
     && pip3 install virtualenv \
     && echo "Dockerfile" >> /etc/buildfiles \
     && echo ".onbuild" >> /etc/buildfiles \

--- a/tests/onbuild/.onbuild
+++ b/tests/onbuild/.onbuild
@@ -1,4 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
-apt-get update
-apt-get install -y wget
+apk-install curl

--- a/tests/onbuild/test.sh
+++ b/tests/onbuild/test.sh
@@ -7,10 +7,10 @@ testOnbuild() {
 		echo "FROM python-runtime:$version" > "$testdir/Dockerfile"
 		docker build -q -t "$image" "$testdir" > /dev/null
 
-		local output="$(docker run --rm $image which wget 2> /dev/null)"
-		assertEquals "wget is not installed" \
-			"/usr/bin/wget" "$output"
-		
+		local output="$(docker run --rm $image which curl 2> /dev/null)"
+		assertEquals "curl is not installed" \
+			"/usr/bin/curl" "$output"
+
 		docker rmi "$image" > /dev/null 2>&1
 	done
 }


### PR DESCRIPTION
Bases the image off of `gliderlabs/alpine` instead of `ubuntu-debootstrap`. A build time and decent image size savings. Alpine Linux to the future!

``` console
$ docker images | grep gliderlabs/python-runtime
gliderlabs/python-runtime   2.7slim             d791a10e73bb        About an hour ago   192 MB
gliderlabs/python-runtime   2.7                 0f09b868e3b4        9 weeks ago         309.9 MB
gliderlabs/python-runtime   3.4slim             09f1484d64e0        About an hour ago   216.7 MB
gliderlabs/python-runtime   3.4                 c8b912c46fd6        9 weeks ago         324.9 MB
```

**Note** that the `build-essential` Ubuntu and `build-base` Alpine meta packages are not identical and provide different build dependencies. We might want to get some tests that do some native Python package compiling to see if common ones fail. This also removes the `ENV` and `MAINTAINER` layers. Let me know if we want to keep those for some reason.

Tests passing at https://circleci.com/gh/gliderlabs/python-runtime/tree/gliderlabs_alpine_base.
